### PR TITLE
fix: sets VueAuth notFoundRedirect path to /dashboard

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ Vue.use(VueAxios, axios);
 Vue.axios.defaults.baseURL = 'https://api.icists.org';
 Vue.use(VueAuth, {
   authRedirect: { path: '/' },
-  notFoundRedirect: { path: '/404' },
+  notFoundRedirect: { path: '/dashboard' },
   refreshData: { url: '/accounts/token-refresh/', method: 'POST', enabled: false, interval: 30 },
   loginData: { url: '/accounts/token-auth/', method: 'POST', redirect: '/dashboard', fetchUser: false },
   fetchData: { url: '/accounts/user/', enabled: false },


### PR DESCRIPTION
fixes #14.

https://github.com/websanova/vue-auth/issues/291

`auth: false`인데 로그인한 유저가 들어오면 notFoundRedirect path로 가네요